### PR TITLE
iai_donbot_sim: Launch files nestable in roslaunch group tags

### DIFF
--- a/iai_donbot_sim/launch/ros_control_sim.launch
+++ b/iai_donbot_sim/launch/ros_control_sim.launch
@@ -1,17 +1,20 @@
 <launch>
+
+  <arg name="tf_prefix" default=""/> <!-- should not start with an forward slash, but end with one -->
+
   <include file="$(find iai_donbot_description)/launch/upload.launch" />
 
   <include file="$(find iai_donbot_sim)/launch/wsg_50_for_kinematic_sim.launch" />
 
   <node pkg="iai_naive_kinematics_sim" type="map_odom_transform_publisher.py" name="map_odom_transform_publisher" output="screen">
     <param name="parent_frame" value="map"/>
-    <param name="child_frame" value="odom"/>
+    <param name="child_frame" value="$(arg tf_prefix)odom"/>
   </node>
 
   <rosparam command="load" file="$(find iai_donbot_sim)/config/ros_control_sim.yaml" />
 
   <node pkg="ros_control_boilerplate" type="sim_hw_main" name="simulator" output="screen">
-    <remap from="joint_states" to="body/joint_states" />
+    <remap from="/$(arg tf_prefix)joint_states" to="/$(arg tf_prefix)body/joint_states" />
   </node>
 
   <node pkg="controller_manager" type="spawner" name="spawner" output="screen" args="joint_state_controller whole_body_controller/body gripper_controller --shutdown-timeout 0.5" />
@@ -19,7 +22,7 @@
   <node pkg="iai_naive_kinematics_sim" type="simulator" name="base_simulator" output="screen">
     <rosparam command="load" file="$(find iai_donbot_sim)/config/naive_kinematics_sim_base.yaml" />
     <remap from="~joint_states" to="base/joint_states" />
-    <remap from="~commands" to="/commands" />
+    <remap from="~commands" to="commands" />
   </node>
 
   <node pkg="joint_state_publisher" type="joint_state_publisher" name="joint_state_publisher" output="screen">
@@ -36,7 +39,9 @@
     <param name="use_gui" value="False"/>
   </node>
 
-  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" />
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
+    <param name="prefix_tf_with" value="$(arg tf_prefix)"/>
+  </node>
 
   <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server" />
 
@@ -44,9 +49,10 @@
     <param name="odom_x_joint" value="odom_x_joint"/>
     <param name="odom_y_joint" value="odom_y_joint"/>
     <param name="odom_z_joint" value="odom_z_joint"/>
-    <param name="odom" value="odom"/>
-    <remap from="~cmd_vel" to="/cmd_vel" />
-    <remap from="~commands" to="/commands" />
+    <param name="odom" value="$(arg tf_prefix)odom"/>
+    <param name="base_footprint" value="$(arg tf_prefix)base_footprint" />
+    <remap from="~cmd_vel" to="cmd_vel" />
+    <remap from="~commands" to="commands" />
   </node>
 
   <include file="$(find omni_pose_follower)/launch/omni_pose_follower.launch"/>

--- a/iai_donbot_sim/launch/ros_control_sim_with_refills_finger.launch
+++ b/iai_donbot_sim/launch/ros_control_sim_with_refills_finger.launch
@@ -1,11 +1,14 @@
 <launch>
+
+  <arg name="tf_prefix" default=""/>
+
   <include file="$(find iai_donbot_description)/launch/upload_with_refills_finger.launch" />
 
   <include file="$(find iai_donbot_sim)/launch/wsg_50_for_kinematic_sim.launch" />
 
   <node pkg="iai_naive_kinematics_sim" type="map_odom_transform_publisher.py" name="map_odom_transform_publisher" output="screen">
     <param name="parent_frame" value="map"/>
-    <param name="child_frame" value="odom"/>
+    <param name="child_frame" value="$(arg tf_prefix)odom"/>
   </node>
 
   <rosparam command="load" file="$(find iai_donbot_sim)/config/ros_control_sim.yaml" />
@@ -19,7 +22,7 @@
   <node pkg="iai_naive_kinematics_sim" type="simulator" name="base_simulator" output="screen">
     <rosparam command="load" file="$(find iai_donbot_sim)/config/naive_kinematics_sim_base.yaml" />
     <remap from="~joint_states" to="base/joint_states" />
-    <remap from="~commands" to="/commands" />
+    <remap from="~commands" to="commands" />
   </node>
 
   <node pkg="joint_state_publisher" type="joint_state_publisher" name="joint_state_publisher" output="screen">
@@ -39,7 +42,9 @@
     <param name="use_gui" value="False"/>
   </node>
 
-  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher" />
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
+    <param name="prefix_tf_with" value="$(arg tf_prefix)"/>
+  </node>
 
   <node pkg="tf2_ros" type="buffer_server" name="tf2_buffer_server" />
 
@@ -47,9 +52,9 @@
     <param name="odom_x_joint" value="odom_x_joint"/>
     <param name="odom_y_joint" value="odom_y_joint"/>
     <param name="odom_z_joint" value="odom_z_joint"/>
-    <param name="odom" value="odom"/>
-    <remap from="~cmd_vel" to="/cmd_vel" />
-    <remap from="~commands" to="/commands" />
+    <param name="odom" value="$(arg tf_prefix)odom"/>
+    <remap from="~cmd_vel" to="cmd_vel" />
+    <remap from="~commands" to="commands" />
   </node>
 
   <include file="$(find omni_pose_follower)/launch/omni_pose_follower.launch"/>

--- a/iai_donbot_sim/launch/wsg_50_for_kinematic_sim.launch
+++ b/iai_donbot_sim/launch/wsg_50_for_kinematic_sim.launch
@@ -3,8 +3,8 @@
 
   <node name="wsg_50_driver" pkg="iai_naive_kinematics_sim" type="wsg_50_faker.py" output="screen" >
     <param name='gripper_joint_name' type='string' value='gripper_joint'/>
-    <remap from="/whole_body_controller/follow_joint_trajectory" to="/gripper_controller/follow_joint_trajectory"/>
-    <remap from="/whole_body_controller/state" to="/gripper_controller/state"/>
+    <param name="gripper_follow_joint_trajectory" type='string' value="gripper_controller/follow_joint_trajectory"/>
+    <param name="gripper_state" type='string' value="gripper_controller/state"/>
   </node>
 
 </launch>


### PR DESCRIPTION
For more info see the PR https://github.com/SemRoCo/giskardpy/pull/94


The name space is automatically inferred from ROS and tf_prefix was added.